### PR TITLE
Fixed the link to the contact form

### DIFF
--- a/config/simple_block.simple_block.build_by_communtiy.yml
+++ b/config/simple_block.simple_block.build_by_communtiy.yml
@@ -7,5 +7,5 @@ dependencies:
 id: build_by_communtiy
 title: 'Built By The Community'
 content:
-  value: "<p><a href=\"/contact\">Contact Us</a> - Built by the community with&nbsp;<a href=\"http://www.drupal.org/\">Drupal</a>&nbsp;and hosted on&nbsp;<a href=\"http://www.pantheon.io/\">Pantheon</a>.</p>\r\n"
+  value: "<p><a href=\"/contact-us\">Contact Us</a> - Built by the community with&nbsp;<a href=\"http://www.drupal.org/\">Drupal</a>&nbsp;and hosted on&nbsp;<a href=\"http://www.pantheon.io/\">Pantheon</a>.</p>\r\n"
   format: full_html


### PR DESCRIPTION
Fixes the link in the footer to reference the correct contact us form. The form already existed just needed to be linked properly.

Closes #23 